### PR TITLE
Fix missing relative field error

### DIFF
--- a/lua/neovim_pets/init.lua
+++ b/lua/neovim_pets/init.lua
@@ -35,7 +35,13 @@ local function move_pet()
   local dc = math.random(-1, 1)
   pet.row = math.max(0, math.min(pet.row + dr, max_row))
   pet.col = math.max(0, math.min(pet.col + dc, max_col))
-  vim.api.nvim_win_set_config(pet.win, { row = pet.row, col = pet.col })
+  -- nvim_win_set_config requires the 'relative' field when updating a
+  -- floating window. Reuse the same setting as when the window was created.
+  vim.api.nvim_win_set_config(pet.win, {
+    relative = 'editor',
+    row = pet.row,
+    col = pet.col,
+  })
 end
 
 local function show_pet()


### PR DESCRIPTION
## Summary
- require `relative` field when moving the floating window

## Testing
- `luajit -v` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f46cb6848320bb971c5336149742