### PR TITLE
Improve pet message pacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Use seu gerenciador de plugins preferido. Exemplo com [lazy.nvim](https://github
 {
   'seuusuario/neovim-pets',
   config = function()
-    require('neovim_pets').setup()
+    require('neovim_pets').setup({
+      -- tempo em segundos entre cada mensagem aleatória
+      message_delay = 5,
+    })
   end,
 }
 ```
@@ -20,5 +23,6 @@ Use seu gerenciador de plugins preferido. Exemplo com [lazy.nvim](https://github
 - Toda vez que uma palavra \xc3\xa9 conclu\xc3\xadda no modo de inser\xc3\xa7\xc3\xa3o, o pet incrementa sua contagem interna.
 - Em determinados limiares (10, 20 e 40 palavras), ele evolui para um novo est\xc3\xa1gio, exibindo um pixel art maior.
 - O plugin tamb\xc3\xa9m exibe mensagens aleat\xc3\xb3rias com emojis para incentivar a digita\xc3\xa7\xc3\xa3o.
+  \xc3\x89 poss\xc3\xadvel definir um intervalo em segundos entre cada mensagem, fazendo com que apare\xc3\xa7am em um ritmo mais tranquilo.
 
 Sinta-se \xc3\xa0 vontade para personalizar os est\xc3\xa1gios do pet e as mensagens no arquivo `lua/neovim_pets/init.lua`.

--- a/lua/neovim_pets/init.lua
+++ b/lua/neovim_pets/init.lua
@@ -13,11 +13,17 @@ local pet = {
   }
 }
 
+local config = {
+  message_delay = 5,
+}
+
+local last_message_time = 0
+
 local messages = {
-  "Vamos brincar! 😊",
-  "Continue digitando! 🐾",
-  "Você está arrasando! 😸",
-  "Isso aí! 🎉",
+  "Que bom te ver digitando bastante! Continue assim e vamos nos divertir muito! 😊",
+  "Continue digitando sem pressa, cada palavra conta para a evolução do nosso amiguinho virtual. 🐾",
+  "Você está arrasando! Não pare agora, ele adora companhia! 😸",
+  "Isso aí! Quanto mais você digita, mais animado ele fica. 🎉",
 }
 
 local function show_pet()
@@ -45,6 +51,11 @@ local function show_pet()
 end
 
 local function random_message()
+  local now = os.time()
+  if now - last_message_time < config.message_delay then
+    return
+  end
+  last_message_time = now
   local msg = messages[math.random(#messages)]
   vim.api.nvim_echo({{msg}}, false, {})
 end
@@ -67,7 +78,11 @@ local function check_word(line)
   end
 end
 
-function M.setup()
+function M.setup(opts)
+  opts = opts or {}
+  if opts.message_delay then
+    config.message_delay = opts.message_delay
+  end
   vim.api.nvim_create_autocmd('TextChangedI', {
     callback = function()
       local line = vim.api.nvim_get_current_line()


### PR DESCRIPTION
## Summary
- add longer pet messages and allow customizing delay between them
- document `message_delay` option in README

## Testing
- `luajit` command not found
- `lua` command not found

------
https://chatgpt.com/codex/tasks/task_e_6849f2dd9774832090462b54cbdbf98a